### PR TITLE
Fix for issue 1 (https://github.com/unruly/java-8-matchers/issues/1).…

### DIFF
--- a/src/main/java/co/unruly/matchers/OptionalMatchers.java
+++ b/src/main/java/co/unruly/matchers/OptionalMatchers.java
@@ -52,11 +52,12 @@ public class OptionalMatchers {
      *
      * @param matcher To match against the Optional's content
      * @param <T> The type of the Optional's content
+     * @param <S> The type matched by the matcher, a subtype of T
      */
-    public static <T> Matcher<Optional<T>> contains(Matcher<T> matcher) {
-        return new TypeSafeMatcher<Optional<T>>() {
+    public static <T, S extends T> Matcher<Optional<S>> contains(Matcher<T> matcher) {
+        return new TypeSafeMatcher<Optional<S>>() {
             @Override
-            protected boolean matchesSafely(Optional<T> item) {
+            protected boolean matchesSafely(Optional<S> item) {
                 return item.map(matcher::matches).orElse(false);
             }
 

--- a/src/test/java/co/unruly/matchers/OptionalMatchersTest.java
+++ b/src/test/java/co/unruly/matchers/OptionalMatchersTest.java
@@ -1,11 +1,15 @@
 package co.unruly.matchers;
 
+import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
@@ -50,6 +54,13 @@ public class OptionalMatchersTest {
     @Test
     public void containsMatcher_success() throws Exception {
         assertThat(Optional.of(4),OptionalMatchers.contains(Matchers.greaterThan(3)));
+    }
+
+    @Test
+    public void containsMatcher_success_typechecksWhenOptionalsArgIsStrictSubtype() {
+        Optional<List<String>> optionalToMatch = Optional.of(Arrays.asList("a"));
+        Matcher<Iterable<? super String>> matcherOfStrictSuperType = hasItem("a");
+        assertThat(optionalToMatch, OptionalMatchers.contains(matcherOfStrictSuperType));
     }
 
     @Test


### PR DESCRIPTION
Fix for issue #1 .  
Make it allowable for type parameter of matcher to be a strict supertype of the type parameter of the optional being matched in OptionalMatchers.contains(Matcher<T>) 
