### PR TITLE
StreamMatchers.contains(..) handles nulls, fixes #3

### DIFF
--- a/src/main/java/co/unruly/matchers/StreamMatchers.java
+++ b/src/main/java/co/unruly/matchers/StreamMatchers.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.PrimitiveIterator;
+import java.util.Objects;
 import java.util.stream.*;
 
 public class StreamMatchers {
@@ -647,7 +648,7 @@ public class StreamMatchers {
                 expectedAccumulator.add(nextExpected);
                 T nextActual = actualIterator.next();
                 actualAccumulator.add(nextActual);
-                if(nextExpected.equals(nextActual)) {
+                if(Objects.equals(nextExpected, nextActual)) {
                     return remainingItemsEqual(expectedIterator, actualIterator);
                 }
             }

--- a/src/test/java/co/unruly/matchers/StreamMatchersTest.java
+++ b/src/test/java/co/unruly/matchers/StreamMatchersTest.java
@@ -81,6 +81,11 @@ public class StreamMatchersTest {
     }
 
     @Test
+    public void contains_is_nullsafe() {
+        assertThat(Stream.of("a", null, "c"), contains("a", null, "c"));
+    }
+
+    @Test
     public void allMatch_success() throws Exception {
         assertThat(Stream.of("bar","baz"),allMatch(containsString("a")));
     }


### PR DESCRIPTION
See issue https://github.com/unruly/java-8-matchers/issues/3
