### PR TITLE
Change StreamMatchers.empty() and StreamMatchers.equalTo() to return the correct parameterised type

### DIFF
--- a/src/main/java/co/unruly/matchers/StreamMatchers.java
+++ b/src/main/java/co/unruly/matchers/StreamMatchers.java
@@ -13,13 +13,13 @@ import java.util.stream.*;
 
 public class StreamMatchers {
 
-    public static <T,S extends BaseStream<T,S>> Matcher<BaseStream<T,S>> empty() {
-        return new TypeSafeMatcher<BaseStream<T, S>>() {
+    public static <T,S extends BaseStream<T,S>> Matcher<S> empty() {
+        return new TypeSafeMatcher<S>() {
 
             private Iterator<T> actualIterator;
 
             @Override
-            protected boolean matchesSafely(BaseStream<T, S> actual) {
+            protected boolean matchesSafely(S actual) {
                 actualIterator = actual.iterator();
                 return !actualIterator.hasNext();
             }
@@ -30,7 +30,7 @@ public class StreamMatchers {
             }
 
             @Override
-            protected void describeMismatchSafely(BaseStream<T, S> item, Description description) {
+            protected void describeMismatchSafely(S item, Description description) {
                 description.appendText("A non empty Stream starting with ").appendValue(actualIterator.next());
             }
         };
@@ -50,10 +50,10 @@ public class StreamMatchers {
      * @see #startsWithLong
      * @see #startsWithDouble
      */
-    public static <T,S extends BaseStream<T,S>> Matcher<BaseStream<T,S>> equalTo(BaseStream<T, S> expected) {
-        return new BaseStreamMatcher<T,BaseStream<T,S>>() {
+    public static <T,S extends BaseStream<T,S>> Matcher<S> equalTo(S expected) {
+        return new BaseStreamMatcher<T,S>() {
             @Override
-            protected boolean matchesSafely(BaseStream<T,S> actual) {
+            protected boolean matchesSafely(S actual) {
                 return remainingItemsEqual(expected.iterator(), actual.iterator());
             }
         };

--- a/src/test/java/co/unruly/matchers/StreamMatchersTest.java
+++ b/src/test/java/co/unruly/matchers/StreamMatchersTest.java
@@ -208,7 +208,7 @@ public class StreamMatchersTest {
 
     @Test
     public void equalTo_failureMessages() throws Exception {
-        Matcher<BaseStream<String, Stream<String>>> matcher = equalTo(Stream.of("a", "b", "c", "d", "e", "f", "g", "h"));
+        Matcher<Stream<String>> matcher = equalTo(Stream.of("a", "b", "c", "d", "e", "f", "g", "h"));
         Stream<String> testData = Stream.of("a", "b", "c", "d", "e");
         Helper.testFailingMatcher(testData, matcher, "Stream of [\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\"]", "Stream of [\"a\",\"b\",\"c\",\"d\",\"e\"]");
     }
@@ -224,7 +224,7 @@ public class StreamMatchersTest {
     @Test
     public void equalToIntStream_failureMessages() throws Exception {
         IntStream testData = IntStream.range(8, 10);
-        Matcher<BaseStream<Integer, IntStream>> matcher = equalTo(IntStream.range(0, 6));
+        Matcher<IntStream> matcher = equalTo(IntStream.range(0, 6));
         Helper.testFailingMatcher(testData, matcher, "Stream of [<0>,<1>,<2>,<3>,<4>,<5>]", "Stream of [<8>,<9>]");
     }
 


### PR DESCRIPTION
Fixes #18.