### PR TITLE
Fix StreamMatchers.equalTo() types

### DIFF
--- a/src/main/java/co/unruly/matchers/StreamMatchers.java
+++ b/src/main/java/co/unruly/matchers/StreamMatchers.java
@@ -7,13 +7,17 @@ import org.hamcrest.TypeSafeMatcher;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.PrimitiveIterator;
 import java.util.Objects;
-import java.util.stream.*;
+import java.util.PrimitiveIterator;
+import java.util.stream.BaseStream;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
 public class StreamMatchers {
 
-    public static <T,S extends BaseStream<T,S>> Matcher<S> empty() {
+    public static <T,S extends BaseStream<T,? extends S>> Matcher<S> empty() {
         return new TypeSafeMatcher<S>() {
 
             private Iterator<T> actualIterator;
@@ -50,7 +54,7 @@ public class StreamMatchers {
      * @see #startsWithLong
      * @see #startsWithDouble
      */
-    public static <T,S extends BaseStream<T,S>> Matcher<S> equalTo(S expected) {
+    public static <T,S extends BaseStream<T,? extends S>> Matcher<S> equalTo(S expected) {
         return new BaseStreamMatcher<T,S>() {
             @Override
             protected boolean matchesSafely(S actual) {
@@ -912,7 +916,7 @@ public class StreamMatchers {
     private static class IntArrayIterator implements PrimitiveIterator.OfInt {
         private final int[] expected;
         private int currentPos = 0;
-        
+
         public IntArrayIterator(int... expected) {
             this.expected = expected;
         }

--- a/src/main/java/co/unruly/matchers/StreamMatchers.java
+++ b/src/main/java/co/unruly/matchers/StreamMatchers.java
@@ -370,7 +370,7 @@ public class StreamMatchers {
      * @see #startsWithDouble(double...)
      */
     @SafeVarargs
-    public static <T,S extends BaseStream<T,S>> Matcher<S> contains(Matcher<T>... expectedMatchers) {
+    public static <T, S extends BaseStream<T, ? extends S>> Matcher<S> contains(Matcher<T>... expectedMatchers) {
         return new BaseMatcherStreamMatcher<T,S>() {
 
             @Override
@@ -393,7 +393,7 @@ public class StreamMatchers {
      * @see #startsWithDouble(double...)
      */
     @SafeVarargs
-    public static <T,S extends BaseStream<T,S>> Matcher<S> contains(T... expected) {
+    public static <T, S extends BaseStream<T, ? extends S>> Matcher<S> contains(T... expected) {
         return new BaseStreamMatcher<T,S>() {
             @Override
             protected boolean matchesSafely(S actual) {

--- a/src/main/java/co/unruly/matchers/StreamMatchers.java
+++ b/src/main/java/co/unruly/matchers/StreamMatchers.java
@@ -13,13 +13,13 @@ import java.util.stream.*;
 
 public class StreamMatchers {
 
-    public static <T,S extends BaseStream<T,S>> Matcher<BaseStream<T,S>> empty() {
-        return new TypeSafeMatcher<BaseStream<T, S>>() {
+    public static <T,S extends BaseStream<T,S>> Matcher<S> empty() {
+        return new TypeSafeMatcher<S>() {
 
             private Iterator<T> actualIterator;
 
             @Override
-            protected boolean matchesSafely(BaseStream<T, S> actual) {
+            protected boolean matchesSafely(S actual) {
                 actualIterator = actual.iterator();
                 return !actualIterator.hasNext();
             }
@@ -30,7 +30,7 @@ public class StreamMatchers {
             }
 
             @Override
-            protected void describeMismatchSafely(BaseStream<T, S> item, Description description) {
+            protected void describeMismatchSafely(S item, Description description) {
                 description.appendText("A non empty Stream starting with ").appendValue(actualIterator.next());
             }
         };
@@ -50,10 +50,10 @@ public class StreamMatchers {
      * @see #startsWithLong
      * @see #startsWithDouble
      */
-    public static <T,S extends BaseStream<T,S>> Matcher<BaseStream<T,S>> equalTo(BaseStream<T, S> expected) {
-        return new BaseStreamMatcher<T,BaseStream<T,S>>() {
+    public static <T,S extends BaseStream<T,S>> Matcher<S> equalTo(S expected) {
+        return new BaseStreamMatcher<T,S>() {
             @Override
-            protected boolean matchesSafely(BaseStream<T,S> actual) {
+            protected boolean matchesSafely(S actual) {
                 return remainingItemsEqual(expected.iterator(), actual.iterator());
             }
         };

--- a/src/test/java/co/unruly/matchers/StreamMatchersTest.java
+++ b/src/test/java/co/unruly/matchers/StreamMatchersTest.java
@@ -236,6 +236,15 @@ public class StreamMatchersTest {
         assertThat("xyz", where(characters, equalTo(Stream.of('x', 'y', 'z'))));
     }
 
+    @Test
+    public void contains_handles_types() {
+        assertThat("xyz", where(s -> s.chars().mapToObj(i -> (char) i), contains('x', 'y', 'z')));
+
+        DescribableFunction<String, BaseStream<Character, Stream<Character>>> characters = s -> s.chars().mapToObj(i -> (char) i);
+        assertThat("xyz", where(characters, contains('x', 'y', 'z')));
+        assertThat("xyz", where(characters, not(contains('x', 'y'))));
+    }
+
 
     @Test
     public void contains_failureMessages() throws Exception {

--- a/src/test/java/co/unruly/matchers/StreamMatchersTest.java
+++ b/src/test/java/co/unruly/matchers/StreamMatchersTest.java
@@ -208,7 +208,7 @@ public class StreamMatchersTest {
 
     @Test
     public void equalTo_failureMessages() throws Exception {
-        Matcher<BaseStream<String, Stream<String>>> matcher = equalTo(Stream.of("a", "b", "c", "d", "e", "f", "g", "h"));
+        Matcher<Stream<String>> matcher = equalTo(Stream.of("a", "b", "c", "d", "e", "f", "g", "h"));
         Stream<String> testData = Stream.of("a", "b", "c", "d", "e");
         Helper.testFailingMatcher(testData, matcher, "Stream of [\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\"]", "Stream of [\"a\",\"b\",\"c\",\"d\",\"e\"]");
     }
@@ -224,7 +224,7 @@ public class StreamMatchersTest {
     @Test
     public void equalToIntStream_failureMessages() throws Exception {
         IntStream testData = IntStream.range(8, 10);
-        Matcher<BaseStream<Integer, IntStream>> matcher = equalTo(IntStream.range(0, 6));
+        Matcher<IntStream> matcher = equalTo(IntStream.range(0, 6));
         Helper.testFailingMatcher(testData, matcher, "Stream of [<0>,<1>,<2>,<3>,<4>,<5>]", "Stream of [<8>,<9>]");
     }
 

--- a/src/test/java/co/unruly/matchers/StreamMatchersTest.java
+++ b/src/test/java/co/unruly/matchers/StreamMatchersTest.java
@@ -33,7 +33,7 @@ public class StreamMatchersTest {
 
     @Test
     public void contains_failureDifferingSingleItem() throws Exception {
-        assertThat(Stream.of("a"), is(not(contains("b"))));
+        assertThat(Stream.of("a"), not(contains("b")));
     }
 
     @Test
@@ -43,7 +43,7 @@ public class StreamMatchersTest {
 
     @Test
     public void contains_failureDifferingLength() throws Exception {
-        assertThat(Stream.of("a"), is(not(contains("a", "b"))));
+        assertThat(Stream.of("a"), not(contains("a", "b")));
     }
 
     @Test
@@ -53,7 +53,7 @@ public class StreamMatchersTest {
 
     @Test
     public void contains_failureDifferingItems() throws Exception {
-        assertThat(Stream.of("a","c"), is(not(contains("a", "b"))));
+        assertThat(Stream.of("a","c"), not(contains("a", "b")));
     }
 
     @Test

--- a/src/test/java/co/unruly/matchers/StreamMatchersTest.java
+++ b/src/test/java/co/unruly/matchers/StreamMatchersTest.java
@@ -1,18 +1,29 @@
 package co.unruly.matchers;
 
+import co.unruly.matchers.function.DescribableFunction;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
-import java.util.stream.*;
+import java.util.stream.BaseStream;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
-import static co.unruly.matchers.StreamMatchers.*;
+import static co.unruly.matchers.Java8Matchers.where;
+import static co.unruly.matchers.StreamMatchers.allMatch;
+import static co.unruly.matchers.StreamMatchers.anyMatch;
 import static co.unruly.matchers.StreamMatchers.contains;
 import static co.unruly.matchers.StreamMatchers.empty;
 import static co.unruly.matchers.StreamMatchers.equalTo;
 import static co.unruly.matchers.StreamMatchers.startsWith;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
+import static co.unruly.matchers.StreamMatchers.startsWithInt;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
 
 public class StreamMatchersTest {
     @Test
@@ -211,6 +222,18 @@ public class StreamMatchersTest {
         Matcher<Stream<String>> matcher = equalTo(Stream.of("a", "b", "c", "d", "e", "f", "g", "h"));
         Stream<String> testData = Stream.of("a", "b", "c", "d", "e");
         Helper.testFailingMatcher(testData, matcher, "Stream of [\"a\",\"b\",\"c\",\"d\",\"e\",\"f\",\"g\",\"h\"]", "Stream of [\"a\",\"b\",\"c\",\"d\",\"e\"]");
+    }
+
+    @Test
+    public void equalTo_handles_types() {
+        Stream<Character> expectedStream = Stream.of('x', 'y', 'z');
+        assertThat("xyz", where(s -> s.chars().mapToObj(i -> (char) i), equalTo(expectedStream)));
+
+        BaseStream<Character, Stream<Character>> expectedBaseStream = Stream.of('x', 'y', 'z');
+        assertThat("xyz", where(s -> s.chars().mapToObj(i -> (char) i), equalTo(expectedBaseStream)));
+
+        DescribableFunction<String, BaseStream<Character, Stream<Character>>> characters = s -> s.chars().mapToObj(i -> (char) i);
+        assertThat("xyz", where(characters, equalTo(Stream.of('x', 'y', 'z'))));
     }
 
 


### PR DESCRIPTION
This is a small addition to #19 to fix some typing. Se discussion here https://github.com/unruly/java-8-matchers/issues/18#issuecomment-612429327

Fixes #18 